### PR TITLE
Set cmake_minimum_required(VERSION 3.5) instead of 2.8.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.5)
 
 project(FreeRDP C CXX)
 

--- a/rdtk/CMakeLists.txt
+++ b/rdtk/CMakeLists.txt
@@ -15,7 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.5)
 
 project(RdTk C)
 

--- a/winpr/CMakeLists.txt
+++ b/winpr/CMakeLists.txt
@@ -15,7 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.5)
 
 project(WinPR C)
 


### PR DESCRIPTION
This bumps the cmake_minimum_required to 3.5 to be compatible with cmake 4.0.